### PR TITLE
Mise en œuvre du symbole mathématique SIGNE MOINS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pour une version complète il faudrait :
  - [x] Implémenter le mode monétaire
  - [x] Implémenter le mode micro
  - [x] Implémenter le mode européen
- - [ ] Voir s'il est nécessaire de distinguer le symbole `TRAIT D'UNION` du symbole `MOINS`
+ - [x] Voir s'il est nécessaire de distinguer le symbole `TRAIT D'UNION` du symbole `MOINS`
  - [ ] Voir s'il est nécessaire de distinguer le symbole `BARRE COUVRANTE` du symbole `BARRE OBLIQUE COUVRANTE`
  - [ ] Changer le . en un vrai DOT BELOW dans le layout overview (touche I)
  - [x] Pour plus de propreté, changer les tabulations en espaces

--- a/fr
+++ b/fr
@@ -1124,7 +1124,7 @@ xkb_symbols "azerty_afnor" {
     key <AD08>  { [ i,        I,          dead_abovedot,  dead_belowdot] };    
     key <AD09>  { [ o,        O,          oe,             OE           ] };    
     key <AD10>  { [ p,        P,          percent,        U2030        ] };
-    key <AD11>  { [ minus,    U2013,      minus,          U2011        ] };
+    key <AD11>  { [ minus,    U2013,      U2212,          U2011        ] };
     key <AD12>  { [ plus,     plusminus,  U2020,          U2021        ] };    
 
     // Third row

--- a/fr_azerty_afnor
+++ b/fr_azerty_afnor
@@ -50,7 +50,7 @@ xkb_symbols "azerty_afnor" {
     key <AD08>  { [ i,        I,          dead_abovedot,  dead_belowdot] };    
     key <AD09>  { [ o,        O,          oe,             OE           ] };    
     key <AD10>  { [ p,        P,          percent,        U2030        ] };
-    key <AD11>  { [ minus,    U2013,      minus,          U2011        ] };
+    key <AD11>  { [ minus,    U2013,      U2212,          U2011        ] };
     key <AD12>  { [ plus,     plusminus,  U2020,          U2021        ] };    
 
     // Third row


### PR DESCRIPTION
Fixes #16 : La combinaison <kbd>AltGr</kbd>+<kbd>-</kbd> doit produire le symbole [SIGNE MOINS](http://www.fileformat.info/info/unicode/char/2212/index.htm).

Le symbole `minus` n'étant pas un trait d'union mais le symbole [TRAIT D'UNION - SIGNE MOINS](http://www.fileformat.info/info/unicode/char/002d/index.htm).